### PR TITLE
(ShiftFastCamera) - Scrolling Speed

### DIFF
--- a/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera.csproj
+++ b/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera.csproj
@@ -42,6 +42,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>..\..\..\..\Editors\ChromapperV0.10\chromapper\ChroMapper_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>Dependencies\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
@@ -55,4 +58,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ChroMapperDir)\Plugins&quot;&#xA;" />
+  </Target>
 </Project>

--- a/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/MB.cs
+++ b/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/MB.cs
@@ -1,20 +1,70 @@
-﻿using UnityEngine;
+﻿using TMPro;
+using UnityEngine;
 
 namespace ChroMapper_ShiftFastCamera
 {
     public class MB : MonoBehaviour
     {
-        private float InitialSpeed;
+        private float _initialSpeed;
+
+        private float _modifiedSpeed;
+
+        private TextMeshProUGUI _speedText;
+        
+        // Shift speed starts at 4x the normal speed, it is maxed at 350, and the minimum is 2x the normal speed.
 
         void Start()
         {
-            InitialSpeed = Settings.Instance.Camera_MovementSpeed;
+            _initialSpeed = Settings.Instance.Camera_MovementSpeed;
+            _modifiedSpeed = _initialSpeed * 4f;
+            
+            _speedText = new GameObject("SpeedText", typeof(TextMeshProUGUI))
+                .GetComponent<TextMeshProUGUI>();
+            _speedText.transform.SetParent(GameObject.Find("Timeline Canvas").transform);
+            _speedText.text = $"Speed: {_modifiedSpeed}";
+            _speedText.rectTransform.anchoredPosition = new Vector2(0, 210);
+            _speedText.fontSize = 32;
+            _speedText.alignment = TextAlignmentOptions.Center;
+            _speedText.horizontalAlignment = HorizontalAlignmentOptions.Center;
+            _speedText.verticalAlignment = VerticalAlignmentOptions.Middle;
+            _speedText.transform.gameObject.SetActive(false);
+            
         }
 
         void Update()
         {
-            if (Input.GetKeyDown(KeyCode.LeftShift)) Settings.Instance.Camera_MovementSpeed = InitialSpeed * 4;
-            if (Input.GetKeyUp(KeyCode.LeftShift)) Settings.Instance.Camera_MovementSpeed = InitialSpeed;
+            // initialSpeed * 4f is the "default" shift speed before it was modified.
+            if (Input.GetKey(KeyCode.LeftShift))
+            {   
+                // This fixes a very specific issue where if you are holding shift and hit esc (menu) and exit the map,
+                // it will save the modified speed as the default speed, it will show 25 in the settings /
+                // however its capped at 25, so its actually 60 if using the CM default cam speed.
+                if (Input.GetKey(KeyCode.Escape)) return; 
+                
+                float scroll = Input.GetAxis("Mouse ScrollWheel");
+                if(scroll != 0)
+                {
+                    // Increment by -1 or 1.
+                    if (scroll > 0)
+                        _modifiedSpeed += 1f;
+                    else
+                        _modifiedSpeed -= 1f;
+                    
+                    if (_modifiedSpeed < _initialSpeed * 2f) _modifiedSpeed = _initialSpeed * 2f; // Prevent lower speed than normal / negative speed.
+                    if (_modifiedSpeed > 350) _modifiedSpeed = 350; // Prevent super high speed, if you are going this high you need fucking help.
+                }
+                
+                if (!_speedText.transform.gameObject.activeInHierarchy) _speedText.transform.gameObject.SetActive(true);
+                _speedText.text = $"Camera Speed : {_modifiedSpeed}";
+                
+                Settings.Instance.Camera_MovementSpeed = _modifiedSpeed;
+            }
+
+            if (Input.GetKeyUp(KeyCode.LeftShift))
+            {
+                Settings.Instance.Camera_MovementSpeed = _initialSpeed;
+                _speedText.transform.gameObject.SetActive(false);
+            }
         }
 
     }

--- a/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/ShiftFastCamera.cs
+++ b/ChroMapper-ShiftFastCamera/ChroMapper-ShiftFastCamera/ShiftFastCamera.cs
@@ -9,15 +9,13 @@ namespace ChroMapper_ShiftFastCamera
         [Init]
         private void Init()
         {
-            SceneManager.sceneLoaded += SceneLoaded;
-        }
-
-        private void SceneLoaded(Scene scene, LoadSceneMode mode)
-        {
-            if (scene.buildIndex == 3)  //Only in the scene where you actually edit the map
+            SceneManager.sceneLoaded += (scene, mode) =>
             {
-                GameObject obj = new GameObject("FastCamera", typeof(MB));
-            }
+                if (scene.buildIndex == 3) // Only in the scene where you actually edit the map
+                {
+                    GameObject obj = new GameObject("FastCamera", typeof(MB));
+                }
+            };
         }
 
         [Exit]


### PR DESCRIPTION
- Allows for changing the shift camera speed via ScrollWheel in increments of 1.
- Added a text element to display current shift speed. (Image below)
- Fixed an issue where exiting the map while holding shift saved the shift camera speed to the camera speed.

![image](https://github.com/user-attachments/assets/dfb18330-4280-4c81-b565-01fa55286967)
